### PR TITLE
Skip modules/functions that start with "_" in autoapi

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,25 +6,37 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'Guipy'
-copyright = '2022, Casey Culbertson, Jason Zhang'
-author = 'Casey Culbertson, Jason Zhang'
-release = '0.0.0'
+project = "Guipy"
+copyright = "2022, Casey Culbertson, Jason Zhang"
+author = "Casey Culbertson, Jason Zhang"
+release = "0.0.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['autoapi.extension']
+extensions = ["autoapi.extension"]
 
-autoapi_type = 'python'
-autoapi_dirs = ['../guipy']
+autoapi_type = "python"
+autoapi_dirs = ["../guipy"]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+def skip_util_classes(app, what, name, obj, skip, options):
+    # if name starts with a _
+    if name.split(".")[-1][0] == "_":
+        skip = True
+    return skip
+
+
+def setup(sphinx):
+    sphinx.connect("autoapi-skip-member", skip_util_classes)
+
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]


### PR DESCRIPTION
Using 
```python
if name.split(".")[-1][0] == "_":
        skip = True
```

To skip any modules or functions that start with "_" the pythonic way.